### PR TITLE
Reduce memory footprint of Network struct

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -44,7 +44,7 @@ func printNetworkInformation(n *network.Network) {
 
 		fmt.Printf("Network:\t%s\n", utils.Itodd(n.Address))
 		fmt.Printf("Mask:\t\t%s (/%d)\n", utils.Itodd(n.Mask), utils.GetBitsInMask(n.Mask))
-		fmt.Printf("Bcast:\t\t%s\n", utils.Itodd(n.BroadcastAddress))
+		fmt.Printf("Bcast:\t\t%s\n", utils.Itodd(n.BroadcastAddress()))
 
 		if VERBOSE_FLAG {
 			fmt.Printf("\n")

--- a/cmd/subnet.go
+++ b/cmd/subnet.go
@@ -86,9 +86,9 @@ func printNetworkTree(node *network.NetworkNode, opts ...int) {
 
 		fmt.Printf("__%s/%d", ip_address, num_of_bits)
 		if node.Utilized && len(node.Subnets) == 0 {
-			fmt.Printf("[%d]*", node.Network.HostCount)
+			fmt.Printf("[%d]*", node.Network.HostCount())
 		} else if len(node.Subnets) == 0 {
-			fmt.Printf("[%d]+", node.Network.HostCount)
+			fmt.Printf("[%d]+", node.Network.HostCount())
 		}
 		fmt.Printf("\n")
 	} else {

--- a/pkg/network/network_node.go
+++ b/pkg/network/network_node.go
@@ -32,7 +32,7 @@ func (node *NetworkNode) Split() error {
 		node.Subnets = append(node.Subnets, &NetworkNode{Network: left_network})
 
 		// right will contain the larger value
-		right_network, err := GenerateNetworkFromBits(left_network.BroadcastAddress+1, new_mask)
+		right_network, err := GenerateNetworkFromBits(left_network.BroadcastAddress()+1, new_mask)
 		if err != nil {
 			return err
 		}
@@ -136,20 +136,20 @@ func SplitToVlsmCount(node *NetworkNode, vlsm_count int) error {
 		// 2. look ahead to what the next host count would be
 		// 3. if our current host count meets the requirement but our next host count doesn't
 		//    then we have found our network
-		current_host_count := node.Network.HostCount
-		var lookahead_host_count uint
+		current_host_count := node.Network.HostCount()
+		var lookahead_host_count int
 		current_mask_bc := utils.GetBitsInMask(node.Network.Mask)
 		lookahead_mask_bc := current_mask_bc + 1
 		if lookahead_mask_bc <= 30 {
 			// the next split will be a legitimate network
 			lookahead_mask, _ := utils.GetMaskFromBits(lookahead_mask_bc)
 			lookahead_network, _ := GenerateNetworkFromBits(node.Network.Address, lookahead_mask)
-			lookahead_host_count = lookahead_network.HostCount
+			lookahead_host_count = lookahead_network.HostCount()
 		} else {
 			lookahead_host_count = 0
 		}
 
-		if current_host_count >= uint(vlsm_count) && lookahead_host_count < uint(vlsm_count) {
+		if current_host_count >= vlsm_count && lookahead_host_count < vlsm_count {
 			// our current_host_count meets the vlsm count requirements
 			// and the next network's count is too small
 			// we've found our spot

--- a/pkg/network/network_node_test.go
+++ b/pkg/network/network_node_test.go
@@ -41,7 +41,7 @@ func TestSplitToHostCount(t *testing.T) {
 		dd_address          string
 		dd_mask             string
 		host_count          int
-		expected_host_count uint
+		expected_host_count int
 		error_string        string
 	}{
 		{"192.168.1.1", "255.255.255.0", 1, 2, ""},
@@ -69,8 +69,8 @@ func TestSplitToHostCount(t *testing.T) {
 			test_node = test_node.Subnets[0]
 		}
 
-		if test_node.Network.HostCount != test_case.expected_host_count {
-			t.Errorf("subnet host count (%d) doesn't match spec (%d)", test_node.Network.HostCount, test_case.host_count)
+		if test_node.Network.HostCount() != test_case.expected_host_count {
+			t.Errorf("subnet host count (%d) doesn't match spec (%d)", test_node.Network.HostCount(), test_case.host_count)
 		}
 	}
 }

--- a/pkg/network/summarize.go
+++ b/pkg/network/summarize.go
@@ -28,6 +28,6 @@ func SummarizeNetworks(networks []*Network) (*Network, error) {
 		commonBits = utils.GetNetworkAddress(commonBits, commonMask)
 	}
 
-	return &Network{Address: commonBits, Mask: commonMask, BroadcastAddress: utils.GetBroadcastAddress(commonBits, commonMask)}, nil
+	return &Network{Address: commonBits, Mask: commonMask}, nil
 
 }


### PR DESCRIPTION
## Problem
When subnetting a very large network (/4 or larger) into a large number of subnetworks (/30) the application will crash.  After investigating utilizing `dmesg` it was determined that the system was running out of memory. 

When subnetting netcalc utilizes a binary tree structure of `NetworkNode` objects.  

```
type NetworkNode struct {
	Network  *Network       `json:"network,omitempty"`
	Utilized bool           `json:"-"`
	Subnets  []*NetworkNode `json:"subnets,omitempty"`
}
```

```
type Network struct {
	Address          uint32 `json:"address"`
	Mask             uint32 `json:"mask"`
	MaskBits         uint32 `json:"-"`
	BroadcastAddress uint32 `json:"broadcast"`
	HostCount        uint   `json:"-"`
}
```
During each recursive subnetting step two networks are added to the Subnets array until the subnet requirements are met.  However, each network that is subnetted is still in memory even though it's not used other than showing the overall  structure of the subnetting process. 

### Testing Results

Estimated memory usage `(2^n + 2^n-2)` * 21 bytes, n = number of bits between base network and subnets.  
The first 2^n represents the number of networks (leaf nodes) that we've subnetted, the second (2^n)-2 represents the tree structure above the leaf nodes (each is a NetworkNode object that contains a Network object.  

| Test Case | Memory Usage (est.) | Time | Notes |
|-----------|----------------------|------|--------|
| `netcalc subnet --hosts 2 1.0.0.0 128.0.0.0 &>/dev/null` | 22.5GB | N/A | Results in crash, out of memory in dmesg log|

## Solution

### Reduce struct size
The first step was to reduce the overall size of the Network object.  It is currently 20 bytes wide and was able to be refactored to be only 8 bytes wide by moving calculated data fields into methods and removing unneeded data fields.  

```
type Network struct {
	Address uint32 `json:"address"` // 32 bits
	Mask    uint32 `json:"mask"`    // 32 bits
} // 8 bytes
```

### Testing Results

Estimated memory usage is (2^n + (2^n)-2) * 8 bytes, n = number of bits between base network and subnets.  

| Test Case | Memory Usage (est.) | Time | Notes |
|-----------|----------------------|------|--------|
| `netcalc subnet --hosts 2 1.0.0.0 128.0.0.0 &>/dev/null` |  8.58GB | 517.58s user 252.47s system 81% cpu 15:45.70 total | Success |